### PR TITLE
double writes

### DIFF
--- a/cmd/raidz_test/raidz_bench.c
+++ b/cmd/raidz_test/raidz_bench.c
@@ -89,7 +89,7 @@ run_gen_bench_impl(const char *impl)
 				    zio_bench.io_abd,
 				    zio_bench.io_size, zio_bench.io_offset,
 				    rto_opts.rto_ashift, ncols+1, ncols,
-				    fn+1, rto_opts.rto_expand_offset);
+				    fn+1, rto_opts.rto_expand_offset, 0);
 			} else {
 				rm_bench = vdev_raidz_map_alloc(&zio_bench,
 				    BENCH_ASHIFT, ncols, fn+1);
@@ -177,7 +177,7 @@ run_rec_bench_impl(const char *impl)
 				    zio_bench.io_abd,
 				    zio_bench.io_size, zio_bench.io_offset,
 				    BENCH_ASHIFT, ncols+1, ncols,
-				    PARITY_PQR, rto_opts.rto_expand_offset);
+				    PARITY_PQR, rto_opts.rto_expand_offset, 0);
 			} else {
 				rm_bench = vdev_raidz_map_alloc(&zio_bench,
 				    BENCH_ASHIFT, ncols, PARITY_PQR);

--- a/cmd/raidz_test/raidz_test.c
+++ b/cmd/raidz_test/raidz_test.c
@@ -326,11 +326,11 @@ init_raidz_golden_map(raidz_test_opts_t *opts, const int parity)
 		opts->rm_golden = vdev_raidz_map_alloc_expanded(opts->zio_golden->io_abd,
 		    opts->zio_golden->io_size, opts->zio_golden->io_offset,
 		    opts->rto_ashift, total_ncols+1, total_ncols,
-		    parity, opts->rto_expand_offset);
+		    parity, opts->rto_expand_offset, 0);
 		rm_test = vdev_raidz_map_alloc_expanded(zio_test->io_abd,
 		    zio_test->io_size, zio_test->io_offset,
 		    opts->rto_ashift, total_ncols+1, total_ncols,
-		    parity, opts->rto_expand_offset);
+		    parity, opts->rto_expand_offset, 0);
 	} else {
 		opts->rm_golden = vdev_raidz_map_alloc(opts->zio_golden,
 		    opts->rto_ashift, total_ncols, parity);
@@ -379,7 +379,7 @@ init_raidz_map(raidz_test_opts_t *opts, zio_t **zio, const int parity)
 		rm = vdev_raidz_map_alloc_expanded((*zio)->io_abd,
 		    (*zio)->io_size, (*zio)->io_offset,
 		    opts->rto_ashift, total_ncols+1, total_ncols,
-		    parity, opts->rto_expand_offset);
+		    parity, opts->rto_expand_offset, 0);
 	} else {
 		rm = vdev_raidz_map_alloc(*zio, opts->rto_ashift,
 		    total_ncols, parity);

--- a/include/sys/vdev_raidz.h
+++ b/include/sys/vdev_raidz.h
@@ -45,7 +45,7 @@ struct kernel_param {};
 struct raidz_map *vdev_raidz_map_alloc(struct zio *, uint64_t, uint64_t,
     uint64_t);
 struct raidz_map *vdev_raidz_map_alloc_expanded(abd_t *, uint64_t, uint64_t,
-    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+    uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
 void vdev_raidz_map_free(struct raidz_map *);
 void vdev_raidz_generate_parity(struct raidz_map *);
 void vdev_raidz_reconstruct(struct raidz_map *, const int *, int);

--- a/include/sys/vdev_raidz_impl.h
+++ b/include/sys/vdev_raidz_impl.h
@@ -133,6 +133,10 @@ typedef struct raidz_col {
 	uint8_t rc_tried;		/* Did we attempt this I/O column? */
 	uint8_t rc_skipped;		/* Did we skip this I/O column? */
 	uint8_t rc_need_orig_restore;	/* need to restore from orig_data? */
+
+	uint64_t rc_shadow_devidx;	/* for double write */
+	uint64_t rc_shadow_offset;	/* for double write */
+	int rc_shadow_error;	/* for double write */
 } raidz_col_t;
 
 typedef struct raidz_row {


### PR DESCRIPTION
When doing a write during a reflow, we may find that this sector was already
copied (or wasn't allocated at the time it would have been copied), but that
progress hasn't yet been reflected on disk, so the primary write is to the old
location.  We need to also write to the already copied (new) location, which is
represented as the "shadow" location.