### PR TITLE
Raidz time dependent geometry (misc improvements)

### DIFF
--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -1921,7 +1921,30 @@ vdev_raidz_close(vdev_t *vd)
 }
 
 static uint64_t
-vdev_raidz_asize(vdev_t *vd, uint64_t psize)
+vdev_raidz_get_logical_width(vdev_raidz_t *vdrz, zio_t *zio)
+{
+#if 1
+	reflow_node_t lookup = {
+		.re_txg = BP_PHYSICAL_BIRTH(zio->io_bp)
+	};
+	avl_index_t where;
+
+	reflow_node_t *re = avl_find(&vdrz->vd_expand_txgs, &lookup, &where);
+	if (re != NULL)
+		return (re->re_logical_width);
+
+	re = avl_nearest(&vdrz->vd_expand_txgs, where, AVL_BEFORE);
+	if (re == NULL)
+		return (vdrz->vd_original_width);
+
+	return (re->re_logical_width);
+#else
+	return (vdrz->vd_original_width);
+#endif
+}
+
+static uint64_t
+vdev_raidz_asize_impl(zio_t *zio, vdev_t *vd, uint64_t psize)
 {
 	vdev_raidz_t *vdrz = vd->vdev_tsd;
 	uint64_t asize;
@@ -1929,6 +1952,9 @@ vdev_raidz_asize(vdev_t *vd, uint64_t psize)
 	/* XXX if this is a new write, need to use new logical width */
 	uint64_t cols = vdrz->vd_original_width;
 	uint64_t nparity = vdrz->vd_nparity;
+
+	if (zio != NULL)
+		cols = vdev_raidz_get_logical_width(vdrz, zio);
 
 	asize = ((psize - 1) >> ashift) + 1;
 	asize += nparity * ((asize + cols - nparity - 1) / (cols - nparity));
@@ -1941,6 +1967,12 @@ vdev_raidz_asize(vdev_t *vd, uint64_t psize)
 	VERIFY3U(asize_new, <=, asize);
 
 	return (asize);
+}
+
+static uint64_t
+vdev_raidz_asize(vdev_t *vd, uint64_t psize)
+{
+	return (vdev_raidz_asize_impl(NULL, vd, psize));
 }
 
 static void
@@ -1961,9 +1993,8 @@ vdev_raidz_shadow_child_done(zio_t *zio)
 	rc->rc_shadow_error = zio->io_error;
 }
 
-#if 0
 static void
-vdev_raidz_io_verify(zio_t *zio, raidz_row_t *rr, int col)
+vdev_raidz_io_verify(zio_t *zio, raidz_map_t *rm, raidz_row_t *rr, int col)
 {
 #ifdef ZFS_DEBUG
 	vdev_t *vd = zio->io_vd;
@@ -1972,14 +2003,19 @@ vdev_raidz_io_verify(zio_t *zio, raidz_row_t *rr, int col)
 	range_seg64_t logical_rs, physical_rs;
 	logical_rs.rs_start = zio->io_offset;
 	logical_rs.rs_end = logical_rs.rs_start +
-	    vdev_raidz_asize(zio->io_vd, zio->io_size);
+	    vdev_raidz_asize_impl(zio, zio->io_vd, zio->io_size);
 
 	raidz_col_t *rc = &rr->rr_col[col];
 	vdev_t *cvd = vd->vdev_child[rc->rc_devidx];
 
 	vdev_xlate(cvd, &logical_rs, &physical_rs);
-	ASSERT3U(rc->rc_offset, ==, physical_rs.rs_start);
+	if (rm->rm_nrows == 1)
+		ASSERT3U(rc->rc_offset, ==, physical_rs.rs_start);
+	else
+		ASSERT3U(rc->rc_offset, >=, physical_rs.rs_start);
+
 	ASSERT3U(rc->rc_offset, <, physical_rs.rs_end);
+
 	/*
 	 * It would be nice to assert that rs_end is equal
 	 * to rc_offset + rc_size but there might be an
@@ -1987,14 +2023,14 @@ vdev_raidz_io_verify(zio_t *zio, raidz_row_t *rr, int col)
 	 * rc_size.
 	 */
 	if (physical_rs.rs_end > rc->rc_offset + rc->rc_size) {
-		ASSERT3U(physical_rs.rs_end, ==, rc->rc_offset +
-		    rc->rc_size + (1 << tvd->vdev_ashift));
+		if (rm->rm_nrows == 1)
+			ASSERT3U(physical_rs.rs_end, ==, rc->rc_offset +
+			    rc->rc_size + (1 << tvd->vdev_ashift));
 	} else {
 		ASSERT3U(physical_rs.rs_end, ==, rc->rc_offset + rc->rc_size);
 	}
 #endif
 }
-#endif
 
 static void
 vdev_raidz_io_start_write(zio_t *zio, raidz_row_t *rr)
@@ -2009,6 +2045,11 @@ vdev_raidz_io_start_write(zio_t *zio, raidz_row_t *rr)
 		if (rc->rc_size == 0)
 			continue;
 		vdev_t *cvd = vd->vdev_child[rc->rc_devidx];
+
+		/*
+		 * Verify physical to logical translation.
+		 */
+		vdev_raidz_io_verify(zio, rm, rr, c);
 
 		zio_nowait(zio_vdev_child_io(zio, NULL, cvd,
 		    rc->rc_offset, rc->rc_abd, rc->rc_size,
@@ -2090,29 +2131,6 @@ vdev_raidz_io_start_read(zio_t *zio, raidz_row_t *rr, boolean_t forceparity)
 			    vdev_raidz_child_done, rc));
 		}
 	}
-}
-
-static uint64_t
-vdev_raidz_get_logical_width(vdev_raidz_t *vdrz, zio_t *zio)
-{
-#if 1
-	reflow_node_t lookup = {
-		.re_txg = BP_PHYSICAL_BIRTH(zio->io_bp)
-	};
-	avl_index_t where;
-
-	reflow_node_t *re = avl_find(&vdrz->vd_expand_txgs, &lookup, &where);
-	if (re != NULL)
-		return (re->re_logical_width);
-
-	re = avl_nearest(&vdrz->vd_expand_txgs, where, AVL_BEFORE);
-	if (re == NULL)
-		return (vdrz->vd_original_width);
-
-	return (re->re_logical_width);
-#else
-	return (vdrz->vd_original_width);
-#endif
 }
 
 /*
@@ -3027,8 +3045,12 @@ vdev_raidz_xlate(vdev_t *cvd, const range_seg64_t *in, range_seg64_t *res)
 	vdev_t *raidvd = cvd->vdev_parent;
 	ASSERT(raidvd->vdev_ops == &vdev_raidz_ops);
 
-	/* XXX deal with different logical and physical widths */
-	uint64_t width = raidvd->vdev_children;
+	vdev_raidz_t *vdrz = raidvd->vdev_tsd;
+	uint64_t children = vdrz->vd_physical_width;
+	if (in->rs_start > vdrz->vn_vre.vre_offset_phys)
+		children--;
+
+	uint64_t width = children;
 	uint64_t tgt_col = cvd->vdev_id;
 	uint64_t ashift = raidvd->vdev_top->vdev_ashift;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
