### PR TITLE
ztest updates

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -7223,6 +7223,9 @@ ztest_freeze(void)
 	spa_t *spa;
 	int numloops = 0;
 
+	if (ztest_raidz_attach_test)
+		return;
+
 	if (ztest_opts.zo_verbose >= 3)
 		(void) printf("testing spa_freeze()...\n");
 

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -3525,8 +3525,7 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	 */
 	if (ztest_device_removal_active) {
 		spa_config_exit(spa, SCL_ALL, FTAG);
-		mutex_exit(&ztest_vdev_lock);
-		return;
+		goto out;
 	}
 
 	/*

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -342,7 +342,6 @@ vdev_raidz_cksum_report(zio_t *zio, zio_cksum_report_t *zcr, void *arg)
 
 	rm->rm_reports++;
 	ASSERT3U(rm->rm_reports, >, 0);
-	ASSERT3U(rm->rm_nrows, ==, 1);
 
 	if (rm->rm_row[0]->rr_abd_copy != NULL)
 		return;


### PR DESCRIPTION
Add raidz expansion as a regular ztest function.
The ztest function above will be called only if raidz is top level device and there are no mirrors.
The example of ztest cmd line args:
% ztest -m 0 -K raidz -r 4

Also, it is possible to control set of ztest functions, which are working in parallel with raidz expansion ztest function using
**zi_raidz_attach_compatible** field of **struct ztest_info**.
