### PR TITLE
Add function to print raidz map

### DIFF
--- a/include/sys/vdev_raidz_impl.h
+++ b/include/sys/vdev_raidz_impl.h
@@ -118,6 +118,7 @@ typedef struct raidz_col {
 	uint8_t rc_skipped;		/* Did we skip this I/O column? */
 	uint8_t rc_need_orig_restore;	/* need to restore from orig_data? */
 	uint8_t rc_repair;		/* Write good data to this column */
+	uint64_t rc_zio_offset;		/* abd offset inside parent zio abd */
 	int rc_shadow_devidx;		/* for double write */
 	int rc_shadow_error;		/* for double write */
 	uint64_t rc_shadow_offset;	/* for double write */
@@ -150,7 +151,10 @@ typedef struct raidz_map {
 	int rm_nskip;			/* RAIDZ sectors skipped for padding */
 	int rm_skipstart;		/* Column index of padding start */
 	int rm_original_width;		/* pre-expansion width of raidz vdev */
+	int rm_logical_width;		/* logical width computed for map */
 	int rm_nphys_cols;		/* Number of leaf devices */
+	uint64_t rm_roffp;		/* Reflow offset phys used by map */
+	uint64_t rm_roff;		/* Reflow offset used by map */
 	zfs_locked_range_t *rm_lr;
 	const raidz_impl_ops_t *rm_ops;	/* RAIDZ math operations */
 	raidz_col_t *rm_phys_col;	/* leaf devices array */


### PR DESCRIPTION
It could be useful to have readable raidz map representation in the dbgmsg in case of raidz debugging manipulations.

The data values which are need to be logged are stored in the raidz_map and filled under raidz_map allocation function.
The dbgmsged raidz_map does not contain information about io aggregation. Only expanded map allocation is fully logged. The values ow=,lw=,pw= could be used to figure out which map function was called to create the map.
Map printing does not have a mutex to avoid performance degradation, it is possible to clearly grep all lines of specified map by combining zio and rm addresses, which are printed in every line.
Original dbgmsgs were not removed because the debug logging is highly individual and strongly dependent from what needed to be debugged.
The PR is compilable only on Linux side.

Example of dbgmsg logs:
vdev_raidz.c:775:vdev_raidz_map_alloc_expanded(): rm=5581a06a55f0 row=8 c=2 dc=1 off=19 devidx=2 offset=76830720 rpc=4
vdev_raidz.c:775:vdev_raidz_map_alloc_expanded(): rm=5581a06a55f0 row=8 c=3 dc=2 off=30 devidx=3 offset=76830720 rpc=4
vdev_raidz.c:775:vdev_raidz_map_alloc_expanded(): rm=5581a06a55f0 row=9 c=1 dc=0 off=9 devidx=1 offset=76831232 rpc=4
vdev_raidz.c:775:vdev_raidz_map_alloc_expanded(): rm=5581a06a55f0 row=9 c=2 dc=1 off=20 devidx=2 offset=76831232 rpc=4
vdev_raidz.c:775:vdev_raidz_map_alloc_expanded(): rm=5581a06a55f0 row=9 c=3 dc=2 off=31 devidx=3 offset=76831232 rpc=4
vdev_raidz.c:775:vdev_raidz_map_alloc_expanded(): rm=5581a06a55f0 row=10 c=1 dc=0 off=10 devidx=1 offset=76831744 rpc=4
vdev_raidz.c:775:vdev_raidz_map_alloc_expanded(): rm=5581a06a55f0 row=10 c=2 dc=1 off=21 devidx=2 offset=76831744 rpc=4
vdev_raidz.c:409:vdev_raidz_dbgmsg_map(): MAP:r:zio=5581a05b9820:rm=5581a06a55f0:blkid=6,off=12512000,sz=4000,ow=4,lw=4,pw=5,txg=258,roffp=100b3400,roff=100b3400,crc=4c988d3
vdev_raidz.c:425:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:row 0
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 0: ziooff=0,off=4944800,sz=200,idx=1,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=a0dad666
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 1: ziooff=0,off=4944800,sz=200,idx=0,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=6e279d9
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 2: ziooff=1600,off=4944800,sz=200,idx=2,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 3: ziooff=2c00,off=4944800,sz=200,idx=3,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=5f6e5ad7
vdev_raidz.c:425:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:row 1
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 0: ziooff=0,off=4944a00,sz=200,idx=1,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=39df1b7f
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 1: ziooff=200,off=4944a00,sz=200,idx=0,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 2: ziooff=1800,off=4944a00,sz=200,idx=2,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 3: ziooff=2e00,off=4944a00,sz=200,idx=3,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=e3d1aa09
vdev_raidz.c:425:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:row 2
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 0: ziooff=0,off=4944c00,sz=200,idx=1,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=8a135dc6
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 1: ziooff=400,off=4944c00,sz=200,idx=0,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 2: ziooff=1a00,off=4944c00,sz=200,idx=2,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 3: ziooff=3000,off=4944c00,sz=200,idx=3,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:425:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:row 3
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 0: ziooff=0,off=4944e00,sz=200,idx=1,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=ac5bd319
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 1: ziooff=600,off=4944e00,sz=200,idx=0,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 2: ziooff=1c00,off=4944e00,sz=200,idx=2,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 3: ziooff=3200,off=4944e00,sz=200,idx=3,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:425:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:row 4
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 0: ziooff=0,off=4945000,sz=200,idx=1,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=4f42139
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 1: ziooff=800,off=4945000,sz=200,idx=0,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 2: ziooff=1e00,off=4945000,sz=200,idx=2,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 3: ziooff=3400,off=4945000,sz=200,idx=3,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:425:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:row 5
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 0: ziooff=0,off=4945200,sz=200,idx=1,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=2b92fd6f
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 1: ziooff=a00,off=4945200,sz=200,idx=0,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 2: ziooff=2000,off=4945200,sz=200,idx=2,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 3: ziooff=3600,off=4945200,sz=200,idx=3,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:425:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:row 6
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 0: ziooff=0,off=4945400,sz=200,idx=1,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=e6d911b3
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 1: ziooff=c00,off=4945400,sz=200,idx=0,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 2: ziooff=2200,off=4945400,sz=200,idx=2,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 3: ziooff=3800,off=4945400,sz=200,idx=3,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:425:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:row 7
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 0: ziooff=0,off=4945600,sz=200,idx=1,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=3e184d74
vdev_raidz.c:2670:vdev_raidz_io_done_verified(): parity_errors=0 parity_untried=0 data_errors=0 verifying=yes
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 1: ziooff=e00,off=4945600,sz=200,idx=0,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 2: ziooff=2400,off=4945600,sz=200,idx=2,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 3: ziooff=3a00,off=4945600,sz=200,idx=3,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=b2aa7578
vdev_raidz.c:425:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:row 8
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 0: ziooff=0,off=4945800,sz=200,idx=1,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=2b34716d
vdev_raidz.c:433:vdev_raidz_dbgmsg_map(): zio=5581a05b9820:rm=5581a06a55f0:col 1: ziooff=1000,off=4945800,sz=200,idx=0,shad_off=ffffffffffffffff,shad_idx=2147483647,err=0,crc=acd629e0