### PR TITLE
Make raidz map allocation functions args lists more compatible

### DIFF
--- a/cmd/raidz_test/raidz_bench.c
+++ b/cmd/raidz_test/raidz_bench.c
@@ -86,8 +86,7 @@ run_gen_bench_impl(const char *impl)
 
 			if (rto_opts.rto_expand) {
 				rm_bench = vdev_raidz_map_alloc_expanded(
-				    zio_bench.io_abd,
-				    zio_bench.io_size, zio_bench.io_offset,
+				    &zio_bench,
 				    rto_opts.rto_ashift, ncols+1, ncols,
 				    fn+1, rto_opts.rto_expand_offset,
 				    0, B_FALSE);
@@ -175,8 +174,7 @@ run_rec_bench_impl(const char *impl)
 
 			if (rto_opts.rto_expand) {
 				rm_bench = vdev_raidz_map_alloc_expanded(
-				    zio_bench.io_abd,
-				    zio_bench.io_size, zio_bench.io_offset,
+				    &zio_bench,
 				    BENCH_ASHIFT, ncols+1, ncols,
 				    PARITY_PQR,
 				    rto_opts.rto_expand_offset, 0, B_FALSE);

--- a/cmd/raidz_test/raidz_test.c
+++ b/cmd/raidz_test/raidz_test.c
@@ -324,12 +324,10 @@ init_raidz_golden_map(raidz_test_opts_t *opts, const int parity)
 
 	if (opts->rto_expand) {
 		opts->rm_golden =
-		    vdev_raidz_map_alloc_expanded(opts->zio_golden->io_abd,
-		    opts->zio_golden->io_size, opts->zio_golden->io_offset,
+		    vdev_raidz_map_alloc_expanded(opts->zio_golden,
 		    opts->rto_ashift, total_ncols+1, total_ncols,
 		    parity, opts->rto_expand_offset, 0, B_FALSE);
-		rm_test = vdev_raidz_map_alloc_expanded(zio_test->io_abd,
-		    zio_test->io_size, zio_test->io_offset,
+		rm_test = vdev_raidz_map_alloc_expanded(zio_test,
 		    opts->rto_ashift, total_ncols+1, total_ncols,
 		    parity, opts->rto_expand_offset, 0, B_FALSE);
 	} else {
@@ -377,8 +375,7 @@ init_raidz_map(raidz_test_opts_t *opts, zio_t **zio, const int parity)
 	init_zio_abd(*zio);
 
 	if (opts->rto_expand) {
-		rm = vdev_raidz_map_alloc_expanded((*zio)->io_abd,
-		    (*zio)->io_size, (*zio)->io_offset,
+		rm = vdev_raidz_map_alloc_expanded(*zio,
 		    opts->rto_ashift, total_ncols+1, total_ncols,
 		    parity, opts->rto_expand_offset, 0, B_FALSE);
 	} else {

--- a/include/sys/vdev_raidz.h
+++ b/include/sys/vdev_raidz.h
@@ -46,7 +46,7 @@ struct kernel_param {};
  */
 struct raidz_map *vdev_raidz_map_alloc(struct zio *, uint64_t, uint64_t,
     uint64_t);
-struct raidz_map *vdev_raidz_map_alloc_expanded(abd_t *, uint64_t, uint64_t,
+struct raidz_map *vdev_raidz_map_alloc_expanded(struct zio *,
     uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, boolean_t);
 void vdev_raidz_map_free(struct raidz_map *);
 void vdev_raidz_free(struct vdev_raidz *);

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -561,11 +561,15 @@ vdev_raidz_map_alloc(zio_t *zio, uint64_t ashift, uint64_t dcols,
  * offset.
  */
 noinline raidz_map_t *
-vdev_raidz_map_alloc_expanded(abd_t *abd, uint64_t size, uint64_t offset,
+vdev_raidz_map_alloc_expanded(zio_t *zio,
     uint64_t ashift, uint64_t physical_cols, uint64_t logical_cols,
     uint64_t nparity, uint64_t reflow_offset_synced,
     uint64_t reflow_offset_next, boolean_t use_scratch)
 {
+	abd_t *abd = zio->io_abd;
+	uint64_t offset = zio->io_offset;
+	uint64_t size = zio->io_size;
+
 	/* The zio's size in units of the vdev's minimum sector size. */
 	uint64_t s = size >> ashift;
 	uint64_t q, r, bc, asize, tot;
@@ -2427,8 +2431,7 @@ vdev_raidz_io_start(zio_t *zio)
 		    next_offset,
 		    use_scratch);
 
-		rm = vdev_raidz_map_alloc_expanded(zio->io_abd,
-		    zio->io_size, zio->io_offset,
+		rm = vdev_raidz_map_alloc_expanded(zio,
 		    tvd->vdev_ashift, vdrz->vd_physical_width,
 		    logical_width, vdrz->vd_nparity,
 		    synced_offset, next_offset, use_scratch);


### PR DESCRIPTION
The vdev_raidz_map_alloc_expanded() have to many arguments, replace first three of them to single zio pointer argument.