### PR TITLE
(ISSUE) ztest_mmp_enable_disable

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -469,7 +469,7 @@ ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_spa_create_destroy, 1, &zopt_sometimes, B_FALSE),
 	ZTI_INIT(ztest_fault_inject, 1, &zopt_sometimes, B_FALSE),
 	ZTI_INIT(ztest_dmu_snapshot_hold, 1, &zopt_sometimes, B_FALSE),
-	ZTI_INIT(ztest_mmp_enable_disable, 1, &zopt_sometimes, B_FALSE),
+	ZTI_INIT(ztest_mmp_enable_disable, 1, &zopt_sometimes, B_TRUE),
 	ZTI_INIT(ztest_reguid, 1, &zopt_rarely, B_FALSE),
 	ZTI_INIT(ztest_scrub, 1, &zopt_rarely, B_FALSE),
 	ZTI_INIT(ztest_spa_upgrade, 1, &zopt_rarely, B_FALSE),

--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -677,7 +677,7 @@ mmp_thread(void *arg)
 			zio_suspend(spa, NULL, ZIO_SUSPEND_MMP);
 		}
 
-		if (multihost && !suspended)
+		if (spa->spa_raidz_expand == NULL && multihost && !suspended)
 			mmp_write_uberblock(spa);
 
 		if (skip_wait > 0) {


### PR DESCRIPTION
WORKAROUND: disable mmp uberblock writing if expansion is in progress (see diff).

I did not managed with reproduction on kernel side (zfs testsuite) using multihost=on zpool option, but it could be reproduced using ztest. The mmp uberblock, which have incorrect reflow offset, is used sometimes and produce bp corruptions.