### PR TITLE
(ISSUE) ztest_vdev_attach_detach

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -474,7 +474,7 @@ ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_scrub, 1, &zopt_rarely, B_FALSE),
 	ZTI_INIT(ztest_spa_upgrade, 1, &zopt_rarely, B_FALSE),
 	ZTI_INIT(ztest_dsl_dataset_promote_busy, 1, &zopt_rarely, B_FALSE),
-	ZTI_INIT(ztest_vdev_attach_detach, 1, &zopt_sometimes, B_FALSE),
+	ZTI_INIT(ztest_vdev_attach_detach, 1, &zopt_sometimes, B_TRUE),
 	ZTI_INIT(ztest_vdev_raidz_attach, 1, &zopt_sometimes, B_TRUE),
 	ZTI_INIT(ztest_vdev_LUN_growth, 1, &zopt_rarely, B_FALSE),
 	ZTI_INIT(ztest_vdev_add_remove, 1, &ztest_opts.zo_vdevtime, B_FALSE),


### PR DESCRIPTION
The bp corruptions could be reproduced if one of raidz children is mirror, as I can see, it happen for blocks placed in scratch object.